### PR TITLE
Use latest fibers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"url": "git://github.com/scriby/asyncblock.git"
 	},
 	"dependencies": {
-		"fibers": "1.0.1",
+		"fibers": "1.0.2",
     "esprima": "1.2.2"
 	},
     "devDependencies": {


### PR DESCRIPTION
Heya,

Love this module, but right now compilation fails on node 0.11.x. Latest fibers at least makes it possible to compile on node 0.11.10.
