### PR TITLE
Fixed broken fibers deployment after Node.js 7.x upgrade

### DIFF
--- a/lib/asyncblock.js
+++ b/lib/asyncblock.js
@@ -9,7 +9,7 @@ var getFibers = (function(){
     var _Fibers;
     return function(){
         if(_Fibers == null){
-            _Fibers = require('fibers-scriby');
+            _Fibers = require('fibers');
         }
 
         return _Fibers;

--- a/lib/flow_fiber.js
+++ b/lib/flow_fiber.js
@@ -6,7 +6,7 @@ var getFibers = (function(){
     var _Fibers;
     return function(){
         if(_Fibers == null){
-            _Fibers = require('fibers-scriby');
+            _Fibers = require('fibers');
         }
 
         return _Fibers;

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
 		"url": "git://github.com/scriby/asyncblock.git"
 	},
 	"dependencies": {
-	    "fibers-scriby": "1.0.8",
-		  "asyncblock-generators": "2.2.8"
+		"fibers": "1.0.15",
+		"asyncblock-generators": "2.2.8"
 	},
-    "devDependencies": {
-        "vows": "0.7.0",
-        "jshint": "0.5.9"
-    }
+	"devDependencies": {
+		"vows": "0.7.0",
+		"jshint": "0.5.9"
+	}
 }

--- a/test_data/transform/sync.js
+++ b/test_data/transform/sync.js
@@ -6,7 +6,7 @@ if(false){
 }
 
 var utility = require('./utility.js');
-var Fiber = require('fibers-scriby');
+var Fiber = require('fibers');
 
 exports.test1 = function(callback){
     asyncblock(function(flow){


### PR DESCRIPTION
"npm install asyncblock" is broken under Node.js 7.x when using fibers-scriby 1.0.8. Should stick to using fibers from mainline.